### PR TITLE
Add support for string as children for WishList.Text

### DIFF
--- a/example/src/AssetList/AssetListSeparator.tsx
+++ b/example/src/AssetList/AssetListSeparator.tsx
@@ -28,9 +28,6 @@ export function AssetListSeparator({
     item.isEditing ? 'Done' : 'Edit',
   );
 
-  const pinTitle = useTemplateValue(() => 'Pin');
-  const hideTitle = useTemplateValue(() => 'Hide');
-
   const onPin = useWorkletCallback(() => {});
   const onHide = useWorkletCallback(() => {});
 
@@ -39,9 +36,9 @@ export function AssetListSeparator({
       <WishList.Switch value={isEditing}>
         <WishList.Case value={true}>
           <View style={styles.buttonGroup}>
-            <Button disabled onPress={onPin} text={pinTitle} active={false} />
+            <Button disabled onPress={onPin} text="Pin" active={false} />
             <View style={styles.margin} />
-            <Button disabled onPress={onHide} text={hideTitle} active={false} />
+            <Button disabled onPress={onHide} text="Hide" active={false} />
           </View>
         </WishList.Case>
 

--- a/src/createTemplateComponent.tsx
+++ b/src/createTemplateComponent.tsx
@@ -156,6 +156,15 @@ export function createTemplateComponent<T extends React.ComponentType<any>>(
             templateValues.push(convertToTemplateValue(value, path));
           }
 
+          if (
+            // @ts-expect-error TODO: fix this.
+            Component === Text &&
+            path[0] === 'children' &&
+            !(value instanceof TemplateValue)
+          ) {
+            templateValues.push(convertToTemplateValue(value, path));
+          }
+
           setInObject(otherProps, path, value);
         }
       });


### PR DESCRIPTION
Accepting string is useful when we have a reusable component that can accept both a string or TemplateValue