### PR TITLE
feat: support reading template values in mapper

### DIFF
--- a/example/src/Chat/ChatItem.tsx
+++ b/example/src/Chat/ChatItem.tsx
@@ -22,11 +22,11 @@ export const Reaction = () => {
   });
 
   const count = useTemplateValue((item: ReactionItemCombined) => {
-    return String(item.ids.length);
+    return item.ids.length;
   });
 
-  const showCounter = useTemplateValue((item: ReactionItemCombined) => {
-    return item.ids.length > 1;
+  const showCounter = useTemplateValue(() => {
+    return count.value() > 1;
   });
 
   const handler = useWorkletCallback((value, rootValue) => {

--- a/src/EventHandler.ts
+++ b/src/EventHandler.ts
@@ -1,9 +1,5 @@
 import { useMemo } from 'react';
-
-const runOnUI = (...args: any[]) => {
-  const f = require('react-native-reanimated').runOnUI; //delay reanimated init
-  return f(...args);
-};
+import { runOnUI } from './Utils';
 
 let done = false;
 const maybeInit = () => {

--- a/src/InflatorRepository.ts
+++ b/src/InflatorRepository.ts
@@ -1,3 +1,6 @@
+import type { TemplateValueUIState } from './TemplateValue';
+import { runOnUI } from './Utils';
+
 export type TemplateItem = {
   [key: string]: TemplateItem | undefined;
 } & {
@@ -46,11 +49,11 @@ export type UIInflatorRegistry = {
     pool: ComponentPool,
     rootValue: any,
   ) => TemplateItem;
-};
-
-const runOnUI = (...args: any[]) => {
-  const f = require('react-native-reanimated').runOnUI; //delay reanimated init
-  return f(...args);
+  getTemplateValueState: (id: string) => TemplateValueUIState | undefined;
+  setTemplateValueState: (id: string, state: TemplateValueUIState) => void;
+  deleteTemplateValueState: (id: string) => void;
+  getCurrentValue: () => any;
+  getCurrentRootValue: () => any;
 };
 
 let done = false;
@@ -65,6 +68,9 @@ const maybeInit = () => {
         string,
         Map<string, Map<string, MappingInflateMethod>>
       >();
+      const templateValueStates = new Map<string, TemplateValueUIState>();
+      let currentValue: any;
+      let currentRootValue: any;
 
       const InflatorRegistry: UIInflatorRegistry = {
         inflateItem: (id, index, pool) => {
@@ -90,6 +96,12 @@ const maybeInit = () => {
           }
         },
         useMappings: (item, value, templateType, id, pool, rootValue) => {
+          // We need to save and restore current values to support things like ForEach
+          // where current value can change.
+          const previousValue = currentValue;
+          const previousRootValue = currentRootValue;
+          currentValue = value;
+          currentRootValue = rootValue;
           const mapping = mappings.get(id)?.get(templateType);
           if (mapping) {
             for (const [nativeId, inflate] of mapping.entries()) {
@@ -99,6 +111,8 @@ const maybeInit = () => {
               }
             }
           }
+          currentValue = previousValue;
+          currentRootValue = previousRootValue;
           return item;
         },
         registerInflator: (id, inflateMethod) => {
@@ -128,6 +142,21 @@ const maybeInit = () => {
           innerMapping.set(nativeId, inflateMethod);
           mapping.set(templateType, innerMapping);
           mappings.set(inflatorId, mapping);
+        },
+        getTemplateValueState: (id) => {
+          return templateValueStates.get(id);
+        },
+        setTemplateValueState: (id, state) => {
+          templateValueStates.set(id, state);
+        },
+        deleteTemplateValueState: (id) => {
+          templateValueStates.delete(id);
+        },
+        getCurrentValue: () => {
+          return currentValue;
+        },
+        getCurrentRootValue: () => {
+          return currentRootValue;
         },
       };
       global.InflatorRegistry = InflatorRegistry;

--- a/src/TemplateValue.tsx
+++ b/src/TemplateValue.tsx
@@ -1,26 +1,107 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
+import { getUIInflatorRegistry } from './InflatorRepository';
+import { generateId, runOnUI } from './Utils';
 
 export type TemplateValueMapper<ItemT, ValueT> = (
   item: ItemT,
   rootValue: any,
 ) => ValueT;
 
-export class TemplateValue<ValueT> {
-  _mapper: TemplateValueMapper<any, ValueT>;
+// Object cloned by reanimated are feezed so we store mutation state in a
+// side map.
+export type TemplateValueUIState = {
+  current: any;
+  dirty: boolean;
+};
 
-  constructor(mapper: TemplateValueMapper<any, ValueT>) {
-    this._mapper = mapper;
+export type TemplateValue<ValueT> = {
+  value: () => ValueT;
+};
+
+export type TemplateValueInternal<ValueT> = TemplateValue<ValueT> & {
+  __isTemplateValue: boolean;
+  __setDirty: () => void;
+  __remove: () => void;
+};
+
+export function createTemplateValue<ValueT>(
+  mapper: TemplateValueMapper<any, ValueT>,
+): TemplateValueInternal<ValueT> {
+  const id = generateId();
+
+  function getOrCreateUIState() {
+    'worklet';
+
+    const registry = getUIInflatorRegistry();
+    let state = registry.getTemplateValueState(id);
+    if (!state) {
+      state = {
+        dirty: true,
+        current: undefined,
+      };
+      registry.setTemplateValueState(id, state);
+    }
+
+    return state;
   }
 
-  getMapper() {
-    return this._mapper;
+  function setDirty() {
+    'worklet';
+
+    const state = getOrCreateUIState();
+    state.dirty = true;
   }
+
+  function value() {
+    'worklet';
+
+    const registry = getUIInflatorRegistry();
+    const state = getOrCreateUIState();
+    if (state.dirty) {
+      state.current = mapper(
+        registry.getCurrentValue(),
+        registry.getCurrentRootValue(),
+      );
+      state.dirty = false;
+    }
+
+    return state.current;
+  }
+
+  function remove() {
+    runOnUI(() => {
+      getUIInflatorRegistry().deleteTemplateValueState(id);
+    });
+  }
+
+  return {
+    __isTemplateValue: true,
+    __setDirty: setDirty,
+    __remove: remove,
+    value,
+  };
+}
+
+export function isTemplateValue(
+  value: unknown,
+): value is TemplateValueInternal<any> {
+  return (
+    value !== null &&
+    typeof value === 'object' &&
+    (value as any).__isTemplateValue === true
+  );
 }
 
 export function useTemplateValue<ItemT, ValueT>(
   mapper: TemplateValueMapper<ItemT, ValueT>,
 ): TemplateValue<ValueT> {
-  return useMemo(() => {
-    return new TemplateValue(mapper);
+  const value = useMemo(() => {
+    return createTemplateValue(mapper);
   }, [mapper]);
+
+  useEffect(() => {
+    return () => value.__remove();
+  }, [value]);
+
+  return value;
 }

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -1,0 +1,12 @@
+export const runOnUI: typeof import('react-native-reanimated')['runOnUI'] = (
+  ...args
+) => {
+  const f = require('react-native-reanimated').runOnUI; //delay reanimated init
+  return f(...args);
+};
+
+let idGenerator = 0;
+
+export function generateId() {
+  return `id_${idGenerator++}`;
+}

--- a/src/WishList.tsx
+++ b/src/WishList.tsx
@@ -34,10 +34,9 @@ import { WishListContext } from './WishListContext';
 import { WishlistIDContext, useWishlistId } from './WishlistIdContext';
 import { IF } from './IF';
 import { Switch, Case } from './Switch';
+import { generateId } from './Utils';
 
 const OffsetComponent = '__offsetComponent';
-let InflatorId = 1000;
-let wishCtr = 0;
 
 type Mapping = {
   templateType?: string;
@@ -242,7 +241,7 @@ const Component = forwardRef(
           InflatorRepository.unregister(inflatorIdRef.current);
         }
         // Register
-        inflatorIdRef.current = (InflatorId++).toString();
+        inflatorIdRef.current = generateId();
         InflatorRepository.register(inflatorIdRef.current, resolvedInflater);
       }
       return inflatorIdRef.current!;
@@ -257,7 +256,7 @@ const Component = forwardRef(
 
     const wishlistId = useRef<{ id: string } | null>(null);
     if (!wishlistId.current) {
-      wishlistId.current = { id: `ID#${wishCtr++}` };
+      wishlistId.current = { id: generateId() };
     }
 
     return (
@@ -313,8 +312,6 @@ function InnerComponent({
   const combinedTemplates = { ...templates, ...nestedTemplates };
 
   const wishlistId = useWishlistId();
-
-  console.log('wishlistIDDD js', wishlistId);
 
   const keys = Object.keys(combinedTemplates);
   // console.log('@@@ Render WishList', inflatorId, keys.join(', '));
@@ -391,7 +388,7 @@ export const WishList = {
     'worklet';
 
     const { children, ...other } = props;
-    item.RawText?.addProps({ text: children });
+    item.RawText?.addProps({ text: String(children) });
     item.addProps(other);
   }),
 


### PR DESCRIPTION
This allows reading other template values from the mapper function of `useTemplateValue`. Note that because of worklet limitations we can only read values that are defined before the current value so something like this fails:

```ts
const a = useTemplateValue(() => b.value());
const b = useTemplateValue(item => item.b);
```