### PR TITLE
fix: rerenders causing content to disapear

### DIFF
--- a/cpp/ComponentsPool.cpp
+++ b/cpp/ComponentsPool.cpp
@@ -18,7 +18,7 @@ Value ShadowNodeBinding::get(Runtime &rt, const PropNameID &nameProp) {
           std::string callbackName = args[0].asString(rt).utf8(rt);
           int tag = this->sn->getTag();
           std::string eventName = std::to_string(tag) + callbackName;
-                std::cout << "register native for name " << eventName << std::endl;
+          std::cout << "register native for name " << eventName << std::endl;
           jsi::Function callback = args[1].asObject(rt).asFunction(rt);
 
           auto handlerRegistry = rt.global()

--- a/cpp/ComponentsPool.h
+++ b/cpp/ComponentsPool.h
@@ -72,10 +72,10 @@ struct ShadowNodeBinding : public jsi::HostObject,
   virtual Value get(Runtime &rt, const PropNameID &nameProp);
 
   virtual void set(Runtime &rt, const PropNameID &name, const Value &value) {
-      std::string str = name.utf8(rt);
-      if (str == "key") {
-          this->key = value.asString(rt).utf8(rt);
-      }
+    std::string str = name.utf8(rt);
+    if (str == "key") {
+      this->key = value.asString(rt).utf8(rt);
+    }
   }
 };
 

--- a/cpp/ShadowNodeCopyMachine.cpp
+++ b/cpp/ShadowNodeCopyMachine.cpp
@@ -20,21 +20,20 @@ std::shared_ptr<const ShadowNode> ShadowNodeCopyMachine::copyShadowSubtree(
   auto const fragment =
       ShadowNodeFamilyFragment{tag -= 2, sn->getSurfaceId(), nullptr};
   auto eventTarget = std::make_shared<EventTarget>(
-                                                   *ReanimatedRuntimeHandler::rtPtr,
-                                                   jsi::Object(*ReanimatedRuntimeHandler::rtPtr),
-                                                   tag);
- 
+      *ReanimatedRuntimeHandler::rtPtr,
+      jsi::Object(*ReanimatedRuntimeHandler::rtPtr),
+      tag);
+
   auto family = // std::make_shared<ShadowNodeFamily>(fragment, nullptr, cd);
       cd.createFamily(
           fragment,
-        eventTarget); // TODO create handler on js side
+          eventTarget); // TODO create handler on js side
   auto const props = cd.cloneProps(propsParserContext, sn->getProps(), {});
   auto const state = cd.createInitialState(ShadowNodeFragment{props}, family);
-   
+
   // prevent fabric from clearing EventTarget
-    auto *familyH =
-        reinterpret_cast<const ShadowNodeFamilyHack *>(family.get());
-    familyH->eventEmitter_->setEnabled(true);
+  auto *familyH = reinterpret_cast<const ShadowNodeFamilyHack *>(family.get());
+  familyH->eventEmitter_->setEnabled(true);
 
   auto shadowNode = cd.createShadowNode(
       ShadowNodeFragment{

--- a/cpp/ViewportObserver.hpp
+++ b/cpp/ViewportObserver.hpp
@@ -23,6 +23,7 @@ struct ViewportObserver {
     std::deque<WishItem> window;
     std::shared_ptr<ShadowNode> wishListNode;
     LayoutContext lc;
+    ShadowNode::SharedListOfShared wishlistChildren = std::make_shared<ShadowNode::ListOfShared>();
     
     void setInitialValues(std::shared_ptr<ShadowNode> wishListNode, LayoutContext lc) {
         this->wishListNode = wishListNode;

--- a/cpp/ViewportObserver.mm
+++ b/cpp/ViewportObserver.mm
@@ -50,6 +50,8 @@ void ViewportObserver::pushChildren()
               }
             }
 
+            wishlistChildren = children;
+
             return sn.clone(ShadowNodeFragment{nullptr, children, nullptr});
           }));
     };

--- a/cpp/Wishlist/MGWishlistComponentDescriptor.h
+++ b/cpp/Wishlist/MGWishlistComponentDescriptor.h
@@ -9,49 +9,28 @@ namespace react {
 
 class MGWishlistComponentDescriptor
     : public ConcreteComponentDescriptor<MGWishlistShadowNode> {
- public:
-  MGWishlistComponentDescriptor(ComponentDescriptorParameters const &parameters)
-      : ConcreteComponentDescriptor(parameters) {}
+  using ConcreteComponentDescriptor::ConcreteComponentDescriptor;
 
-  // TODO think about it
-  virtual ShadowNode::Shared createShadowNode(
-      const ShadowNodeFragment &fragment,
-      ShadowNodeFamily::Shared const &family) const override {
-    auto shadowNode = std::make_shared<MGWishlistShadowNode>(
-        ShadowNodeFragment{fragment.props, nullptr, fragment.state},
-        family,
-        getTraits());
-    shadowNode->sharedThis = shadowNode;
-
-    adopt(shadowNode);
-
-    return shadowNode;
-  }
-
-  // TODO fix this
-  virtual ShadowNode::Unshared cloneShadowNode(
+  ShadowNode::Unshared cloneShadowNode(
       const ShadowNode &sourceShadowNode,
       const ShadowNodeFragment &fragment) const override {
-    ShadowNode::Unshared shadowNode(nullptr);
-    if (ViewportObserver::isPushingChildren) {
-      shadowNode =
-          std::make_shared<MGWishlistShadowNode>(sourceShadowNode, fragment);
-    } else {
-      shadowNode = std::make_shared<MGWishlistShadowNode>(
-          sourceShadowNode, ShadowNodeFragment{});
-    }
+    auto &wishlistSourceShadowNode =
+        static_cast<const MGWishlistShadowNode &>(sourceShadowNode);
 
-    std::shared_ptr<MGWishlistShadowNode> wishlistShadowNode =
-        std::static_pointer_cast<MGWishlistShadowNode>(shadowNode);
-    /*MGWishlistShadowNode->registeredViews = static_cast<const
-     * MGWishlistShadowNode&>(sourceShadowNode).registeredViews;*/
-    wishlistShadowNode->sharedThis = wishlistShadowNode;
+    // When we clone this shadow node we need to make sure to use the
+    // latest children of the viewport observer, otherwise react might
+    // set the children back to what was rendered.
+    auto shadowNode = std::make_shared<MGWishlistShadowNode>(
+        sourceShadowNode,
+        ShadowNodeFragment{
+            fragment.props,
+            wishlistSourceShadowNode.getStateData()
+                .viewportObserver->wishlistChildren,
+            fragment.state});
 
     adopt(shadowNode);
     return shadowNode;
   }
-
-  virtual ~MGWishlistComponentDescriptor() {}
 };
 
 } // namespace react

--- a/cpp/Wishlist/MGWishlistShadowNode.cpp
+++ b/cpp/Wishlist/MGWishlistShadowNode.cpp
@@ -5,5 +5,48 @@ namespace react {
 
 extern const char MGWishlistComponentName[] = "MGWishlist";
 
+MGWishlistShadowNode::MGWishlistShadowNode(
+    ShadowNodeFragment const &fragment,
+    ShadowNodeFamily::Shared const &family,
+    ShadowNodeTraits traits)
+    : ConcreteViewShadowNode(fragment, family, traits) {}
+
+MGWishlistShadowNode::MGWishlistShadowNode(
+    ShadowNode const &sourceShadowNode,
+    ShadowNodeFragment const &fragment)
+    : ConcreteViewShadowNode(sourceShadowNode, fragment) {}
+
+void MGWishlistShadowNode::layout(LayoutContext layoutContext) {
+  auto state = getStateData();
+  if (!state.initialised) {
+    state.initialised = true;
+    state.viewportObserver->setInitialValues(shared_from_this(), layoutContext);
+
+    setStateData(std::move(state));
+  }
+
+  ConcreteViewShadowNode::layout(layoutContext);
+
+  // TODO update viewportObserver if needed
+
+  updateStateIfNeeded();
+}
+
+void MGWishlistShadowNode::updateStateIfNeeded() {
+  ensureUnsealed();
+
+  auto contentBoundingRect = Rect{};
+  for (const auto &childNode : getLayoutableChildNodes()) {
+    contentBoundingRect.unionInPlace(childNode->getLayoutMetrics().frame);
+  }
+
+  auto state = getStateData();
+
+  if (state.contentBoundingRect != contentBoundingRect) {
+    state.contentBoundingRect = contentBoundingRect;
+    setStateData(std::move(state));
+  }
+}
+
 } // namespace react
 } // namespace facebook

--- a/cpp/Wishlist/MGWishlistShadowNode.h
+++ b/cpp/Wishlist/MGWishlistShadowNode.h
@@ -4,13 +4,8 @@
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/renderer/components/wishlist/EventEmitters.h>
 #include <react/renderer/components/wishlist/Props.h>
-#include <iostream>
-#include <memory>
-#include "LayoutConstraints.h"
 #include "LayoutContext.h"
 #include "MGWishlistState.h"
-#include "ReanimatedRuntimeHandler.hpp"
-#include "ShadowNodeCopyMachine.h"
 
 namespace facebook {
 namespace react {
@@ -20,82 +15,29 @@ JSI_EXPORT extern const char MGWishlistComponentName[];
 /*
  * `ShadowNode` for <Wishlist> component.
  */
-
 class JSI_EXPORT MGWishlistShadowNode
     : public ConcreteViewShadowNode<
           MGWishlistComponentName,
           MGWishlistProps,
           MGWishlistEventEmitter,
           MGWishlistState>,
-      std::enable_shared_from_this<MGWishlistShadowNode> {
+      public std::enable_shared_from_this<MGWishlistShadowNode> {
  public:
   MGWishlistShadowNode(
       ShadowNodeFragment const &fragment,
       ShadowNodeFamily::Shared const &family,
-      ShadowNodeTraits traits)
-      : ConcreteViewShadowNode(fragment, family, traits) {}
+      ShadowNodeTraits traits);
 
   MGWishlistShadowNode(
       ShadowNode const &sourceShadowNode,
-      ShadowNodeFragment const &fragment)
-      : ConcreteViewShadowNode(sourceShadowNode, fragment) {
-    try {
-      const MGWishlistShadowNode &msn =
-          dynamic_cast<const MGWishlistShadowNode &>(sourceShadowNode);
-      registeredViews = msn.registeredViews;
+      ShadowNodeFragment const &fragment);
 
-    } catch (std::bad_cast) {
-    }
-  }
+  using ConcreteViewShadowNode::ConcreteViewShadowNode;
 
-  void realAppendChild(ShadowNode::Shared const &childNode) {
-    if (childNode == nullptr) {
-      return;
-    }
-    ConcreteViewShadowNode::appendChild(childNode);
-  }
+  void layout(LayoutContext layoutContext) override;
 
-  void appendChild(ShadowNode::Shared const &childNode) {
-    return;
-  }
-
-  void layout(LayoutContext layoutContext) {
-    auto state = getStateData();
-    if (!state.initialised) {
-      state.initialised = true;
-      state.viewportObserver->setInitialValues(
-          sharedThis.lock(), layoutContext);
-
-      setStateData(std::move(state));
-    }
-    // TODO update viewportObserver if needed
-
-    ConcreteViewShadowNode::layout(layoutContext);
-
-    // updateScrollContentOffsetIfNeeded();
-    updateStateIfNeeded();
-  }
-
-  void updateStateIfNeeded() {
-    ensureUnsealed();
-
-    auto contentBoundingRect = Rect{};
-    for (const auto &childNode : getLayoutableChildNodes()) {
-      contentBoundingRect.unionInPlace(childNode->getLayoutMetrics().frame);
-    }
-
-    auto state = getStateData();
-
-    if (state.contentBoundingRect != contentBoundingRect) {
-      state.contentBoundingRect = contentBoundingRect;
-      setStateData(std::move(state));
-    }
-  }
-
-  virtual ~MGWishlistShadowNode() {}
-
-  std::vector<std::shared_ptr<ShadowNode const>> registeredViews;
-  std::weak_ptr<MGWishlistShadowNode> sharedThis;
+ private:
+  void updateStateIfNeeded();
 };
 
 } // namespace react

--- a/ios/Orchestrator/MGScrollViewOrchestrator.mm
+++ b/ios/Orchestrator/MGScrollViewOrchestrator.mm
@@ -60,7 +60,7 @@
     _doWeHaveOngoingEvent = NO;
     _inflatorId = inflatorId;
     _touchEvents = [NSMutableArray new];
-      rerenderAllItems = NO;
+    rerenderAllItems = NO;
 
     [self adjustOffsetIfInitialValueIsCloseToEnd];
   }
@@ -147,22 +147,27 @@
     CGPoint oldOffset = _scrollView.contentOffset;
     _scrollView.contentOffset = CGPointMake(oldOffset.x, oldOffset.y - yDiff);
   }
-    
-    [self syncData];
+
+  [self syncData];
 
   // rerender dirty items
   if (!dirtyItems.empty()) {
     std::set<std::string> localDirtyItems;
     localDirtyItems.swap(dirtyItems);
-      if (!rerenderAllItems) {
-          _viewportObserver->rerenderDirtyItems(std::move(localDirtyItems));
-      }
+    if (!rerenderAllItems) {
+      _viewportObserver->rerenderDirtyItems(std::move(localDirtyItems));
+    }
   }
 
   // update teamplates if needed
   if (_doWeHavePendingTemplates or rerenderAllItems) {
     _viewportObserver->update(
-        _scrollView.frame.size.height, _scrollView.frame.size.width, _pendingTemplates, _pendingNames, _inflatorId, rerenderAllItems && !_doWeHaveOngoingEvent);
+        _scrollView.frame.size.height,
+        _scrollView.frame.size.width,
+        _pendingTemplates,
+        _pendingNames,
+        _inflatorId,
+        rerenderAllItems && !_doWeHaveOngoingEvent);
     _doWeHavePendingTemplates = NO;
     rerenderAllItems = NO;
   }
@@ -212,7 +217,8 @@
   }
 
   // pause Vsync listener if there is nothing to do
-  if ([_touchEvents count] == 0 && _currentAnimation == nil && !_doWeHavePendingTemplates && dirtyItems.empty() && !rerenderAllItems) {
+  if ([_touchEvents count] == 0 && _currentAnimation == nil && !_doWeHavePendingTemplates && dirtyItems.empty() &&
+      !rerenderAllItems) {
     [_displayLink setPaused:YES];
   }
 }
@@ -262,19 +268,19 @@
 
 - (void)syncData
 {
-    jsi::Runtime &rt = *ReanimatedRuntimeHandler::rtPtr;
-    jsi::Object global = rt.global().getPropertyAsObject(rt, "global");
-    if (!global.hasProperty(rt, "wishlists")) {
-      global.setProperty(rt, "wishlists", jsi::Object(rt));
-    }
+  jsi::Runtime &rt = *ReanimatedRuntimeHandler::rtPtr;
+  jsi::Object global = rt.global().getPropertyAsObject(rt, "global");
+  if (!global.hasProperty(rt, "wishlists")) {
+    global.setProperty(rt, "wishlists", jsi::Object(rt));
+  }
 
-    jsi::Object wishlists = global.getPropertyAsObject(rt, "wishlists");
-    jsi::Object obj = wishlists.getPropertyAsObject(rt, _wishlistId.c_str());
-    jsi::Value val = obj.getProperty(rt, "listener");
-    if (val.isObject()) {
-        jsi::Function f = val.getObject(rt).getFunction(rt);
-        f.call(rt);
-    }
+  jsi::Object wishlists = global.getPropertyAsObject(rt, "wishlists");
+  jsi::Object obj = wishlists.getPropertyAsObject(rt, _wishlistId.c_str());
+  jsi::Value val = obj.getProperty(rt, "listener");
+  if (val.isObject()) {
+    jsi::Function f = val.getObject(rt).getFunction(rt);
+    f.call(rt);
+  }
 }
 
 - (void)registerWishlistBinding
@@ -308,18 +314,17 @@
             [weakSelf markItemsDirty:keys];
             return jsi::Value::undefined();
           }));
-    binding.setProperty(
-        rt,
-        "markAllItemsDirty",
-        jsi::Function::createFromHostFunction(
-            rt,
-            jsi::PropNameID::forAscii(rt, "markAllItemsDirty"),
-            1,
-            [=](jsi::Runtime &rt, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
-              
-              [weakSelf markAllItemsDirty];
-              return jsi::Value::undefined();
-            }));
+  binding.setProperty(
+      rt,
+      "markAllItemsDirty",
+      jsi::Function::createFromHostFunction(
+          rt,
+          jsi::PropNameID::forAscii(rt, "markAllItemsDirty"),
+          1,
+          [=](jsi::Runtime &rt, const jsi::Value &thisValue, const jsi::Value *args, size_t count) -> jsi::Value {
+            [weakSelf markAllItemsDirty];
+            return jsi::Value::undefined();
+          }));
 
   wishlists.setProperty(rt, _wishlistId.c_str(), binding);
   NSLog(@"registered binding for wishlistId: %@", [NSString stringWithUTF8String:_wishlistId.c_str()]);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "release": "release-it",
     "example": "yarn --cwd example",
     "bootstrap": "yarn example && yarn install && yarn example pods",
-    "clang-format": "clang-format -i --glob='{ios,android,lib}/**/*.{h,cpp,m,mm}'"
+    "clang-format": "clang-format -i --glob='{ios,android,cpp}/**/*.{h,cpp,m,mm}'"
   },
   "keywords": [
     "react-native",


### PR DESCRIPTION
Currently when react re-renders wishlist it causes the shadow node to lose its children, until the next call to update the viewport (usually a scroll event). This is because react seems to hold onto the initial version of the shadow node, which has no children. To make sure we always render using the right children I save the latest children on viewport observer and whenever we clone a Wishlist shadow node we can use these children instead of whatever was passed in.

Also fix clang format script to include cpp/ dir.

Before this change clicking on the add reaction button would cause the list to disappear. This also fixes flickers when the list is re-rendered.