### PR TITLE
fix: example reactions, rngh patch

### DIFF
--- a/example/patches/react-native-gesture-handler+2.8.0.patch
+++ b/example/patches/react-native-gesture-handler+2.8.0.patch
@@ -1,13 +1,37 @@
+diff --git a/node_modules/react-native-gesture-handler/ios/RNGestureHandlerActionType.h b/node_modules/react-native-gesture-handler/ios/RNGestureHandlerActionType.h
+index f05fc12..e543e9a 100644
+--- a/node_modules/react-native-gesture-handler/ios/RNGestureHandlerActionType.h
++++ b/node_modules/react-native-gesture-handler/ios/RNGestureHandlerActionType.h
+@@ -5,4 +5,5 @@ typedef NS_ENUM(NSInteger, RNGestureHandlerActionType) {
+     RNGestureHandlerActionTypeNativeAnimatedEvent, // Animated.event with useNativeDriver: true
+     RNGestureHandlerActionTypeJSFunctionOldAPI, // JS function or Animated.event with useNativeDriver: false using old RNGH API
+     RNGestureHandlerActionTypeJSFunctionNewAPI, // JS function or Animated.event with useNativeDriver: false using new RNGH API
++    RNGestureHandlerActionTypeDirectEvent, // Direct event that can be intercepted by native modules
+ };
 diff --git a/node_modules/react-native-gesture-handler/ios/RNGestureHandlerManager.mm b/node_modules/react-native-gesture-handler/ios/RNGestureHandlerManager.mm
-index 8c2d99d..062c145 100644
+index 8c2d99d..095011a 100644
 --- a/node_modules/react-native-gesture-handler/ios/RNGestureHandlerManager.mm
 +++ b/node_modules/react-native-gesture-handler/ios/RNGestureHandlerManager.mm
-@@ -276,7 +276,7 @@
- {
-   // Delivers the event to JS (old RNGH API).
- #ifdef RN_FABRIC_ENABLED
--  [self sendEventForDeviceEvent:event];
-+  [self sendEventForDirectEvent:event];
- #else
-   [self sendEventForDirectEvent:event];
- #endif // RN_FABRIC_ENABLED
+@@ -243,6 +243,10 @@
+     case RNGestureHandlerActionTypeJSFunctionNewAPI:
+       [self sendEventForJSFunctionNewAPI:event];
+       break;
++      
++    case RNGestureHandlerActionTypeDirectEvent:
++      [self sendEventForDirectEvent:event];
++      break;
+   }
+ }
+ 
+diff --git a/node_modules/react-native-gesture-handler/src/ActionType.ts b/node_modules/react-native-gesture-handler/src/ActionType.ts
+index ac11a32..f78c3f6 100644
+--- a/node_modules/react-native-gesture-handler/src/ActionType.ts
++++ b/node_modules/react-native-gesture-handler/src/ActionType.ts
+@@ -3,6 +3,7 @@ export const ActionType = {
+   NATIVE_ANIMATED_EVENT: 2,
+   JS_FUNCTION_OLD_API: 3,
+   JS_FUNCTION_NEW_API: 4,
++  DIRECT_EVENT: 5,
+ } as const;
+ 
+ // eslint-disable-next-line @typescript-eslint/no-redeclare -- backward compatibility; it can be used as a type and as a value

--- a/example/src/Chat/ChatExample.tsx
+++ b/example/src/Chat/ChatExample.tsx
@@ -29,18 +29,24 @@ export default function App() {
     }, 500);
   }, []);
 
-  const [activeMessageForReaction, setActiveReactionPicker] =
-    useState<ChatItem | null>(null);
+  const [activeMessageIdForReaction, setActiveMessageIdForReaction] = useState<
+    string | null
+  >(null);
 
   const showAddReactionModal = useCallback((item: ChatItem) => {
-    setActiveReactionPicker(item);
+    setActiveMessageIdForReaction(item.key);
   }, []);
 
   const onAddReaction = createRunInJsFn(showAddReactionModal);
 
   const onPickReaction = (emoji: string) => {
-    console.log(emoji);
-    setActiveReactionPicker(null);
+    listRef.current?.update((dataCopy) => {
+      'worklet';
+      const oldValue = dataCopy.get(activeMessageIdForReaction!)!;
+      oldValue.reactions.push({ emoji, key: Math.random().toString() });
+      dataCopy.set(activeMessageIdForReaction!, oldValue);
+    });
+    setActiveMessageIdForReaction(null);
   };
 
   if (!data.length) {
@@ -66,7 +72,7 @@ export default function App() {
         />
         <MessageInput onSend={handleSend} />
       </View>
-      {activeMessageForReaction && (
+      {activeMessageIdForReaction && (
         <ReactionPicker onPickReaction={onPickReaction} />
       )}
     </>

--- a/example/src/Chat/MessageInput.tsx
+++ b/example/src/Chat/MessageInput.tsx
@@ -21,6 +21,7 @@ export function MessageInput({ onSend }: MessageInputProps) {
         style={styles.input}
         value={value}
         onChangeText={setValue}
+        onSubmitEditing={handlePress}
       />
       <BorderlessButton onPress={handlePress} style={styles.button}>
         <Text style={[styles.text, !!value && styles.active]}>Send</Text>

--- a/src/Components/Pressable.tsx
+++ b/src/Components/Pressable.tsx
@@ -10,6 +10,7 @@ const ActionType = {
   NATIVE_ANIMATED_EVENT: 2,
   JS_FUNCTION_OLD_API: 3,
   JS_FUNCTION_NEW_API: 4,
+  DIRECT_EVENT: 5,
 } as const;
 
 type ActionTypeT = typeof ActionType[keyof typeof ActionType];
@@ -68,7 +69,7 @@ const attachGestureHandler = createRunInJsFn((tag: number) => {
   RNGestureHandlerModule.attachGestureHandler(
     handlerTag,
     tag,
-    ActionType.JS_FUNCTION_OLD_API,
+    ActionType.DIRECT_EVENT,
   );
   RNGestureHandlerModule.flushOperations();
 });


### PR DESCRIPTION
The RNGH patch actually broke buttons, so fixed it with something that we could upstream and doesn't conflict with regular usage. Also fixed business logic for adding reactions. This exposed a crash when adding message / adding reaction that will need to be investigated.