### PR TITLE
Fix prepareForRecycle

### DIFF
--- a/ios/MGWishListComponent.mm
+++ b/ios/MGWishListComponent.mm
@@ -151,6 +151,7 @@ using namespace facebook::react;
 {
   _sharedState.reset();
   _orchestrator = nil;
+  alreadyRendered = false;
   [super prepareForRecycle];
 }
 


### PR DESCRIPTION
Fabric reuses native views and we need to make sure that everything is reset properly. This pr fixes issue with creating a new Wishlist that actually is not aware that it wasn't rendered before as it still keeps the old state of the previous component. 