### PR TITLE
feat: scroll to item on android

### DIFF
--- a/android/src/main/java/com/wishlist/Orchestrator.kt
+++ b/android/src/main/java/com/wishlist/Orchestrator.kt
@@ -2,8 +2,9 @@ package com.wishlist
 
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import com.facebook.react.uimanager.PixelUtil
 
-class Orchestrator(wishlistId: String, viewportCarerRef: Int) {
+class Orchestrator(private val mWishlist: Wishlist, wishlistId: String, viewportCarerRef: Int) {
   companion object {
     init {
       WishlistSoLoader.staticInit()
@@ -25,4 +26,11 @@ class Orchestrator(wishlistId: String, viewportCarerRef: Int) {
   )
 
   external fun didScrollAsync(width: Float, height: Float, contentOffset: Float, inflatorId: String)
+
+  external fun scrollToItem(index: Int)
+
+  @DoNotStrip
+  private fun scrollToOffset(offset: Float) {
+    mWishlist.reactSmoothScrollTo(0, PixelUtil.toPixelFromDIP(offset).toInt())
+  }
 }

--- a/android/src/main/java/com/wishlist/Wishlist.kt
+++ b/android/src/main/java/com/wishlist/Wishlist.kt
@@ -14,20 +14,16 @@ class Wishlist(reactContext: Context) :
   private var orchestrator: Orchestrator? = null
   private var templatesRef: Int? = null
   private var names: List<String>? = null
-  private var didInitialRender = false
   private var didInitialScroll = false
   private val initialOffset = 100000f
 
   fun setTemplates(templatesRef: Int, names: List<String>) {
     this.templatesRef = templatesRef
     this.names = names
-    initialRenderIfReady()
+    renderIfReady()
   }
 
-  private fun initialRenderIfReady() {
-    if (didInitialRender) {
-      return
-    }
+  private fun renderIfReady() {
     val templatesRef = this.templatesRef
     val inflatorId = this.inflatorId
     val names = this.names
@@ -38,7 +34,8 @@ class Wishlist(reactContext: Context) :
     var orchestrator = this.orchestrator
     if (orchestrator == null) {
       orchestrator =
-          Orchestrator(wishlistId!!, fabricViewStateManager.stateData!!.getInt("viewportCarer"))
+          Orchestrator(
+              this, wishlistId!!, fabricViewStateManager.stateData!!.getInt("viewportCarer"))
       this.orchestrator = orchestrator
     }
 
@@ -50,8 +47,6 @@ class Wishlist(reactContext: Context) :
         templatesRef,
         names,
         inflatorId)
-
-    didInitialRender = true
   }
 
   private fun initialScrollIfReady() {
@@ -84,7 +79,7 @@ class Wishlist(reactContext: Context) :
   override fun onLayout(changed: Boolean, l: Int, t: Int, r: Int, b: Int) {
     super.onLayout(changed, l, t, r, b)
 
-    initialRenderIfReady()
+    renderIfReady()
     initialScrollIfReady()
   }
 
@@ -98,5 +93,7 @@ class Wishlist(reactContext: Context) :
         inflatorId!!)
   }
 
-  fun scrollToItem(index: Int, animated: Boolean) {}
+  fun scrollToItem(index: Int, animated: Boolean) {
+    orchestrator?.scrollToItem(index)
+  }
 }

--- a/android/src/main/java/com/wishlist/WishlistViewManager.kt
+++ b/android/src/main/java/com/wishlist/WishlistViewManager.kt
@@ -1,5 +1,6 @@
 package com.wishlist
 
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ReactStylesDiffMap
 import com.facebook.react.uimanager.StateWrapper
@@ -15,11 +16,13 @@ class WishlistViewManager : ViewGroupManager<Wishlist>(), MGWishlistManagerInter
     const val REACT_CLASS = "MGWishlist"
   }
 
+  private val mDelegate = MGWishlistManagerDelegate(this)
+
   override fun getName() = REACT_CLASS
 
   override fun createViewInstance(reactContext: ThemedReactContext) = Wishlist(reactContext)
 
-  override fun getDelegate() = MGWishlistManagerDelegate(this)
+  override fun getDelegate() = mDelegate
 
   override fun updateState(
       view: Wishlist,
@@ -42,5 +45,9 @@ class WishlistViewManager : ViewGroupManager<Wishlist>(), MGWishlistManagerInter
 
   override fun scrollToItem(view: Wishlist, index: Int, animated: Boolean) {
     view.scrollToItem(index, animated)
+  }
+
+  override fun receiveCommand(root: Wishlist, commandId: String?, args: ReadableArray?) {
+    mDelegate.receiveCommand(root, commandId, args)
   }
 }

--- a/android/src/main/jni/Orchestrator.hpp
+++ b/android/src/main/jni/Orchestrator.hpp
@@ -9,7 +9,10 @@ namespace Wishlist {
 
 class Orchestrator : public jni::HybridClass<Orchestrator> {
  public:
-  Orchestrator(const std::string &wishlistId, int viewportCarerRef);
+  Orchestrator(
+      jni::alias_ref<Orchestrator::javaobject> jThis,
+      const std::string &wishlistId,
+      int viewportCarerRef);
 
   static constexpr auto kJavaDescriptor = "Lcom/wishlist/Orchestrator;";
 
@@ -17,7 +20,7 @@ class Orchestrator : public jni::HybridClass<Orchestrator> {
 
  private:
   static jni::local_ref<jhybriddata> initHybrid(
-      jni::alias_ref<jclass>,
+      jni::alias_ref<jhybridobject> jThis,
       std::string wishlistId,
       int viewportCarerRef);
 
@@ -36,22 +39,29 @@ class Orchestrator : public jni::HybridClass<Orchestrator> {
       float contentOffset,
       std::string inflatorId);
 
- private:
   void handleVSync();
+
+  void scrollToItem(int index);
+
+  void didPushChildren(std::vector<Item> items);
 
   class Adapter final : public MGPushChildrenListener, public MGVSyncRequester {
    public:
-    Adapter(std::function<void()> onRequestVSync);
+    Adapter(
+        std::function<void()> onRequestVSync,
+        std::function<void(std::vector<Item> items)> didPushChildren);
 
    private:
     void didPushChildren(std::vector<Item> newWindow) override;
     void requestVSync() override;
 
     std::function<void()> onRequestVSync_;
+    std::function<void(std::vector<Item> items)> didPushChildren_;
   };
 
   friend HybridBase;
 
+  jni::global_ref<Orchestrator::javaobject> javaPart_;
   bool alreadyRendered_;
   std::shared_ptr<MGDIImpl> di_;
   std::shared_ptr<Adapter> adapter_;
@@ -59,6 +69,8 @@ class Orchestrator : public jni::HybridClass<Orchestrator> {
   float height_;
   float contentOffset_;
   std::string inflatorId_;
+  std::vector<Item> items_;
+  int pendingScrollToItem_;
 };
 
 } // namespace Wishlist

--- a/src/Wishlist.tsx
+++ b/src/Wishlist.tsx
@@ -72,7 +72,9 @@ function ComponentBase<T extends BaseItem>(
   { children, style, data, ...rest }: Props,
   ref: React.Ref<WishListInstance>,
 ) {
-  const nativeWishlist = useRef(null); // TODO type it properly
+  const nativeWishlist = useRef<InstanceType<typeof NativeWishList> | null>(
+    null,
+  );
   const wishlistId = useRef<string | null>(null);
   if (!wishlistId.current) {
     wishlistId.current = generateId();


### PR DESCRIPTION
Implements basic support for scroll to item on Android. This doesn't yet implement a method for scrolling smoothly to items outside the window, it currently just keeps calling smoothScrollTo until the item is rendered, which makes the scroll to animation kind of slow.