### PR TITLE
feat: add support for react-native v0.73

### DIFF
--- a/cpp/ContentContainer/MGContentContainerComponentDescriptor.h
+++ b/cpp/ContentContainer/MGContentContainerComponentDescriptor.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <react/renderer/components/view/ConcreteViewShadowNode.h>
-#include <react/renderer/core/ConcreteComponentDescriptor.h>
+#include <React-Fabric/react/renderer/components/view/ConcreteViewShadowNode.h>
+#include <React-Fabric/react/renderer/core/ConcreteComponentDescriptor.h>
 #include <iostream>
 #include "MGContentContainerShadowNode.h"
 
@@ -29,8 +29,8 @@ class MGContentContainerComponentDescriptor
                 ? mostRecentStateData.wishlistChildren
                 : fragment.children,
             fragment.state});
-
-    adopt(shadowNode);
+          
+    // adopt(shadowNode);
     return shadowNode;
   }
 };

--- a/cpp/DependencyInjection/MGUIManagerHolder.h
+++ b/cpp/DependencyInjection/MGUIManagerHolder.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <react/renderer/uimanager/UIManager.h>
+#include <React-Fabric/react/renderer/uimanager/UIManager.h>
 
 using namespace facebook::react;
 

--- a/cpp/ItemProvider/ComponentsPool.h
+++ b/cpp/ItemProvider/ComponentsPool.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <react/renderer/core/ConcreteComponentDescriptor.h>
+#include <React-Fabric/react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <stdio.h>
 #include <map>
 #include <memory>

--- a/cpp/ItemProvider/ShadowNodeBinding.h
+++ b/cpp/ItemProvider/ShadowNodeBinding.h
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <react/renderer/core/ConcreteComponentDescriptor.h>
+#include <React-Fabric/react/renderer/components/view/ConcreteViewShadowNode.h>
+#include <React-Fabric/react/renderer/core/ComponentDescriptor.h>
 #include <stdio.h>
 #include <map>
 #include <memory>

--- a/cpp/ItemProvider/ShadowNodeCopyMachine.cpp
+++ b/cpp/ItemProvider/ShadowNodeCopyMachine.cpp
@@ -20,10 +20,10 @@ ShadowNode::Shared ShadowNodeCopyMachine::copyShadowSubtree(
   auto const fragment =
       ShadowNodeFamilyFragment{tag -= 2, sn->getSurfaceId(), nullptr};
   auto &rt = WishlistJsRuntime::getInstance().getRuntime();
-  auto const eventTarget =
-      std::make_shared<EventTarget>(rt, jsi::Object(rt), tag);
+  // auto const eventTarget =
+  //     std::make_shared<EventTarget>(rt, jsi::Object(rt), tag);
 
-  auto const family = cd.createFamily(fragment, eventTarget);
+  auto const family = cd.createFamily(fragment);
   auto const props = cd.cloneProps(
       propsParserContext,
       sn->getProps(),
@@ -33,7 +33,7 @@ ShadowNode::Shared ShadowNodeCopyMachine::copyShadowSubtree(
       {}
 #endif
   );
-  auto const state = cd.createInitialState(ShadowNodeFragment{props}, family);
+  auto const state = cd.createInitialState(props, family);
 
   // prevent fabric from clearing EventTarget
   auto const *familyH =

--- a/cpp/ItemProvider/ShadowNodeCopyMachine.h
+++ b/cpp/ItemProvider/ShadowNodeCopyMachine.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <react/renderer/components/view/ConcreteViewShadowNode.h>
+#include <React-Fabric/react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <react/renderer/components/wishlist/Props.h>
 #include <react/renderer/core/LayoutConstraints.h>
 #include <react/renderer/core/LayoutContext.h>
@@ -24,11 +24,10 @@ class ShadowNodeFamilyHack final {
   using Shared = std::shared_ptr<ShadowNodeFamily const>;
   using Weak = std::weak_ptr<ShadowNodeFamily const>;
 
-  using AncestorList = butter::small_vector<
+  using AncestorList = std::vector<
       std::pair<
           std::reference_wrapper<ShadowNode const> /* parentNode */,
-          int /* childIndex */>,
-      64>;
+          int /* childIndex */>>;
 
   mutable std::unique_ptr<folly::dynamic> nativeProps_DEPRECATED;
   EventDispatcher::Weak eventDispatcher_;
@@ -42,6 +41,7 @@ class ShadowNodeFamilyHack final {
   ComponentName componentName_;
   mutable ShadowNodeFamily::Weak parent_{};
   mutable bool hasParent_{false};
+  InstanceHandle::Shared const instanceHandle_;
 };
 
 }; // namespace Wishlist

--- a/cpp/TemplateContainer/MGTemplateContainerComponentDescriptor.h
+++ b/cpp/TemplateContainer/MGTemplateContainerComponentDescriptor.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <react/renderer/components/view/ConcreteViewShadowNode.h>
-#include <react/renderer/core/ConcreteComponentDescriptor.h>
+#include <React-Fabric/react/renderer/components/view/ConcreteViewShadowNode.h>
 #include <iostream>
 #include "MGTemplateContainerShadowNode.h"
 

--- a/cpp/TemplateContainer/MGTemplateContainerState.h
+++ b/cpp/TemplateContainer/MGTemplateContainerState.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <react/renderer/core/ShadowNode.h>
+#include <React-Fabric/react/renderer/core/ShadowNode.h>
 #include <vector>
 
 #ifdef ANDROID

--- a/cpp/Wishlist/MGWishlistComponentDescriptor.h
+++ b/cpp/Wishlist/MGWishlistComponentDescriptor.h
@@ -1,7 +1,7 @@
 
 #pragma once
 
-#include <react/renderer/core/ConcreteComponentDescriptor.h>
+#include <React-Fabric/react/renderer/components/view/ConcreteViewShadowNode.h>
 #include "MGWishlistShadowNode.h"
 
 namespace facebook {

--- a/ios/MGWishlistManager.mm
+++ b/ios/MGWishlistManager.mm
@@ -9,7 +9,7 @@
 #import <ReactCommon/RCTTurboModule.h>
 #include <jsi/JSIDynamic.h>
 #include <jsi/jsi.h>
-#include <react/renderer/components/view/ViewEventEmitter.h>
+#include <React-Fabric/react/renderer/components/view/ViewEventEmitter.h>
 #include <react/renderer/core/EventListener.h>
 #include "MGObjCJSIUtils.h"
 #include "MGUIManagerHolder.h"
@@ -84,7 +84,7 @@ RCT_EXPORT_MODULE(WishlistManager);
     return false;
 
   WishlistJsRuntime::getInstance().accessRuntime([=](jsi::Runtime &rt) {
-    [self sendEventWithType:jsi::String::createFromUtf8(rt, type) tag:tag payload:event.payloadFactory(rt)];
+      [self sendEventWithType:jsi::String::createFromUtf8(rt, type) tag:tag payload:event.eventPayload->asJSIValue(rt)];
   });
 
   return true;


### PR DESCRIPTION
react-native v0.73 changed a few internal classes regarding ShadowNodes.
I've updated the corresponding headers and function calls to the best of my knowledge.

The current state compiles, but I've commented out the "adopt" function call in `MGContentContainerComponentDescriptor.h`, because I couldn't get the types to work properly. It would be nice if someone could help me with that :)

Other than that, I want to thank the entire margelo team for creating this amazing library.
Please don't be discouraged to work on this library. You've truly created something revolutionary, which has a bright future for the react-native space.